### PR TITLE
Optimized GDMA renderer, added extension change for GBC

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,7 @@ ASMFLAGS        :=  -p0
 FIXFLAGS        :=  -O -f gh
 FIX16			:=	0
 DX				:=	0
+ROM_EXT			:=  gb
 
 ifeq ($(FIX16),0)
 ifeq ($(DX),0)
@@ -33,6 +34,7 @@ PROJECT_NAME    =  	fb2k_dx
 SRC_ASM			+= 	$(SRC_DIR)/dx.asm
 ifeq ($(DX),2)
 ASMFLAGS 		+= 	-D _USE_GDMA
+ROM_EXT			:= gbc
 endif
 endif
 
@@ -46,8 +48,8 @@ LINKERFLAGS     :=  -m $(OUTPUT).map -n $(OUTPUT).sym -d
 all: build
 
 build: $(OBJ_FILES)
-	$(LINKER) -O fb2k.gb -o $(OUTPUT).gb $(LINKERFLAGS) $(OBJ_FILES)
-	$(FIX) $(FIXFLAGS) $(OUTPUT).gb
+	$(LINKER) -O fb2k.gb -o $(OUTPUT).$(ROM_EXT) $(LINKERFLAGS) $(OBJ_FILES)
+	$(FIX) $(FIXFLAGS) $(OUTPUT).$(ROM_EXT)
  
 $(BUILD_DIR)/obj/%.obj : src/%.asm | $(OBJ_DIRS)
 	$(ASM) -o $@ $(ASMFLAGS) $<

--- a/README.md
+++ b/README.md
@@ -77,4 +77,5 @@ Official Nintendo Hardware:
 - AGB/AGS - Untested
 
 Hardware Clones:
+- "Extension Converter for GB" (GB Boy Colour) - Pretty much flawless
 - FunnyPlaying FP-GBC FW1.14 - Same as CGB, but has crashed on me at least once.


### PR DESCRIPTION
Re-did my GDMA math, so in theory since no window nor object interruptions are happening (Since this game uses neither), GDMA can copy up to 8 tiles per scanline, but I've left it at 7 for now, which is still a 3.5x gain! Also commented the code further to explain my reasoning

Now when the game builds for GBC-Only, the extension is also changed to .gbc

Also added mention of GB Boy Colour on the README. I tested on a modified "Extension Converter for GB" SNES cartridge, which is just a GB Boy Colour clone system in a cart with a composite chip, so the CPU acts the exact same as on a normal GB Boy Colour.